### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/src/modules/components/pomodoro.js
+++ b/src/modules/components/pomodoro.js
@@ -302,6 +302,12 @@ function pomodoroInit(timer, itemData, state, columnNum, itemNum) {
 
   function resetPomodoro(e) {
     const itemsLoaded = getLocalItems();
+    
+    // Validate itemNum to prevent prototype pollution
+    if (['__proto__', 'constructor', 'prototype'].includes(itemNum)) {
+      throw new Error('Invalid itemNum value');
+    }
+    
     const itemData = itemsLoaded[Object.keys(itemsLoaded)[columnNum]].items[itemNum];
     const lastFocusedIcon = document.querySelector('[data-pomodoro="true"]');
     const lastFocusedParentId = lastFocusedIcon.closest('.task__list-item').dataset.id;

--- a/src/modules/components/task/relocate.js
+++ b/src/modules/components/task/relocate.js
@@ -8,8 +8,13 @@ import { getLocalItems, setLocalItems, getLocalData } from '../../update/localSt
 
 function relocateItem(columnNum, itemNum, newColNum, newItemNum) {
   checkFunctionParameters(columnNum, itemNum, newColNum, newItemNum);
-  const itemsLoaded = getLocalItems();
 
+  // Validate itemNum to prevent prototype pollution
+  if (['__proto__', 'constructor', 'prototype'].includes(itemNum)) {
+    throw new Error('Invalid itemNum value');
+  }
+
+  const itemsLoaded = getLocalItems();
   const currentColumnItems = itemsLoaded[Object.keys(itemsLoaded)[columnNum]].items;
   const newColumnItems = itemsLoaded[Object.keys(itemsLoaded)[newColNum]].items;
 


### PR DESCRIPTION
Potential fix for [https://github.com/mux-mux/kanban/security/code-scanning/6](https://github.com/mux-mux/kanban/security/code-scanning/6)

To fix the issue, we need to validate the `itemNum` value to ensure it cannot be used to modify `Object.prototype`. This can be achieved by:
1. Checking that `itemNum` is a valid numeric index or conforms to the expected format.
2. Rejecting or sanitizing any input that matches dangerous keys like `__proto__`, `constructor`, or `prototype`.

The best approach is to add a validation step in the `relocateItem` function in `src/modules/components/task/relocate.js`, as this is a central point where `itemNum` is used. Additionally, we should validate `itemNum` in `resetPomodoro` in `src/modules/components/pomodoro.js` to ensure safety.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
